### PR TITLE
fix: #54 - new contributor karma card broken logo

### DIFF
--- a/src/constants/rank.ts
+++ b/src/constants/rank.ts
@@ -53,7 +53,7 @@ export const CONTRIBUTOR_RANKS = [
   {
     title: "New Contributor",
     description: "You've made your first contribution!",
-    logoSrc: "/logos/github-karma-rank-6-logo.png",
+    logoSrc: "/logos/github-karma-logo.png",
     minKarma: 300,
   },
   {


### PR DESCRIPTION
## Description

The non-existent logo image name has been replaced with a valid image name.

## Tests

Currently, it has only been tested locally as the contributor karma card is in preview/development phase.